### PR TITLE
DEVX-2402: Add a support of the --yes flag to aio templates:install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-cli-plugin-app-templates",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Discover, Install, Uninstall, Submit, Remove Adobe App Builder templates",
   "repository": {
     "type": "git",

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -16,6 +16,7 @@ const { writeObjectToPackageJson, readPackageJson, getNpmDependency, processNpmP
 const ora = require('ora')
 const yeoman = require('yeoman-environment')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app-templates:templates:install', { provider: 'debug' })
+const { Flags } = require('@oclif/core')
 
 // aio-lib-console-project-installation dependencies
 const path = require('path')
@@ -24,7 +25,7 @@ const templateHandler = require('@adobe/aio-lib-console-project-installation')
 
 class InstallCommand extends BaseCommand {
   async run () {
-    const { args } = await this.parse(InstallCommand)
+    const { args, flags } = await this.parse(InstallCommand)
     let templateName
 
     const spinner = ora()
@@ -50,6 +51,9 @@ class InstallCommand extends BaseCommand {
     await env.run('template-to-run',
       {
         options: {
+          'skip-prompt': flags.yes,
+          // do not prompt for overwrites
+          force: true,
           // do not install dependencies as they have been installed already
           'skip-install': true
         }
@@ -125,7 +129,12 @@ InstallCommand.args = [
 ]
 
 InstallCommand.flags = {
-  ...BaseCommand.flags
+  ...BaseCommand.flags,
+  yes: Flags.boolean({
+    description: 'Skip questions, and use all default values',
+    default: false,
+    char: 'y'
+  })
 }
 
 module.exports = InstallCommand


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the `--yes` flag to be compatible with `aio app init`

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DEVX-2402

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
