### PR TITLE
DEVX-2367: no login use case support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 -->
 # aio-cli-plugin-app-templates
-Discover, Install, Uninstall Adobe App Builder templates
+Discover, Install, Uninstall, Submit, Remove Adobe App Builder templates
 
 ---
 
@@ -22,10 +22,10 @@ Discover, Install, Uninstall Adobe App Builder templates
   - [`aio templates:discover`](#aio-templatesdiscover)
   - [`aio templates:info`](#aio-templatesinfo)
   - [`aio templates:install`](#aio-templatesinstall)
-  - [`aio templates:rollback`](#aio-templatesrollback)
-  - [`aio templates:uninstall`](#aio-templatesuninstall)
-  - [`aio templates:submit`](#aio-templatessubmit)
   - [`aio templates:remove`](#aio-templatesremove)
+  - [`aio templates:rollback`](#aio-templatesrollback)
+  - [`aio templates:submit`](#aio-templatessubmit)
+  - [`aio templates:uninstall`](#aio-templatesuninstall)
 - [Contributing](#contributing)
 - [Licensing](#licensing)
 <!-- tocstop -->
@@ -56,7 +56,7 @@ COMMANDS
   templates:install    Install an Adobe Developer App Builder template
   templates:remove     Remove template from registry
   templates:rollback   Clears all installed templates
-  templates:submit     Submit template for review 
+  templates:submit     Submit template for review
   templates:uninstall  Uninstall an Adobe Developer App Builder template
 ```
 ## `aio templates:discover`
@@ -166,7 +166,7 @@ USAGE
 
 ARGUMENTS
   PACKAGE-NAME  package name of the template
-  GITHUB-URL    URL of github repository 
+  GITHUB-URL    URL of github repository
 
 OPTIONS
   -v, --verbose  Verbose output

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 -->
 # aio-cli-plugin-app-templates
-Discover, Install, Uninstall, Submit, Remove Adobe App Builder templates
+Discover, Install, Uninstall, Submit, and Remove Adobe App Builder templates
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-cli-plugin-app-templates",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Discover, Install, Uninstall, Submit, Remove Adobe App Builder templates",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-cli-plugin-app-templates",
   "version": "1.0.0-beta.5",
-  "description": "Discover, Install, Uninstall, Submit, Remove Adobe App Builder templates",
+  "description": "Discover, Install, Uninstall, Submit, and Remove Adobe App Builder templates",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/adobe/aio-cli-plugin-app-templates.git"

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -60,8 +60,10 @@ class InstallCommand extends BaseCommand {
       })
     spinner.succeed(`Finished running template ${templateName}`)
 
-    // Setup Developer Console App Builder project from template install.yml configuration file
-    await this.setConsoleProjectConfig(templateName)
+    if (flags['process-install-config']) {
+      // Setup Developer Console App Builder project from template install.yml configuration file
+      await this.setConsoleProjectConfig(templateName)
+    }
 
     const installedTemplates = packageJson[TEMPLATE_PACKAGE_JSON_KEY] || []
     aioLogger.debug(`installed templates in package.json: ${JSON.stringify(installedTemplates, null, 2)}`)
@@ -134,6 +136,11 @@ InstallCommand.flags = {
     description: 'Skip questions, and use all default values',
     default: false,
     char: 'y'
+  }),
+  'process-install-config': Flags.boolean({
+    description: '[default: true] Process the template install.yml configuration file, defaults to true, to skip processing install.yml use --no-process-install-config',
+    default: true,
+    allowNo: true
   })
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the `--no-process-install-config` flag to `aio templates:install` command to support the `aio app init --no-login` use case

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DEVX-2367

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
