### PR TITLE
feat: ACNA-1728 - add template options support to app-templates plugin (install command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,56 +9,89 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 -->
+
 # aio-cli-plugin-app-templates
+
 Discover, Install, Uninstall, Submit, and Remove Adobe App Builder templates
 
 ---
 
 <!-- toc -->
-- [aio-cli-plugin-app-templates](#aio-cli-plugin-app-templates)
-- [Usage](#usage)
-- [Commands](#commands)
-  - [`aio templates`](#aio-templates)
-  - [`aio templates:discover`](#aio-templatesdiscover)
-  - [`aio templates:info`](#aio-templatesinfo)
-  - [`aio templates:install`](#aio-templatesinstall)
-  - [`aio templates:remove`](#aio-templatesremove)
-  - [`aio templates:rollback`](#aio-templatesrollback)
-  - [`aio templates:submit`](#aio-templatessubmit)
-  - [`aio templates:uninstall`](#aio-templatesuninstall)
-- [Contributing](#contributing)
-- [Licensing](#licensing)
+* [aio-cli-plugin-app-templates](#aio-cli-plugin-app-templates)
+* [Usage](#usage)
+* [Commands](#commands)
+* [Contributing](#contributing)
+* [Licensing](#licensing)
 <!-- tocstop -->
 
 # Usage
+
 ```sh-session
-$ aio plugins:install @adobe/aio-cli-plugin-app-templates
-$ # OR
-$ aio discover -i
-$ aio aio-cli-plugin-app-templates --help
+aio plugins:install @adobe/aio-cli-plugin-app-templates
+## OR
+aio discover -i
+aio aio-cli-plugin-app-templates --help
 ```
 
 # Commands
+<!-- commands -->
+* [`aio templates`](#aio-templates)
+* [`aio templates:disco`](#aio-templatesdisco)
+* [`aio templates:discover`](#aio-templatesdiscover)
+* [`aio templates:i PATH`](#aio-templatesi-path)
+* [`aio templates:info`](#aio-templatesinfo)
+* [`aio templates:install PATH`](#aio-templatesinstall-path)
+* [`aio templates:r NAME`](#aio-templatesr-name)
+* [`aio templates:remove NAME`](#aio-templatesremove-name)
+* [`aio templates:rollb`](#aio-templatesrollb)
+* [`aio templates:rollback`](#aio-templatesrollback)
+* [`aio templates:s NAME GITHUBREPOURL`](#aio-templatess-name-githubrepourl)
+* [`aio templates:submit NAME GITHUBREPOURL`](#aio-templatessubmit-name-githubrepourl)
+* [`aio templates:un PACKAGE-NAME`](#aio-templatesun-package-name)
+* [`aio templates:uninstall PACKAGE-NAME`](#aio-templatesuninstall-package-name)
+
 ## `aio templates`
 
 Discover, install, or uninstall a new template into an existing Adobe Developer App Builder App
 
 ```
 USAGE
-  $ aio templates
+  $ aio templates [-v]
 
-OPTIONS
+FLAGS
   -v, --verbose  Verbose output
 
-COMMANDS
-  templates:discover   Discover App Builder templates to install
-  templates:info       List all App Builder templates that are installed
-  templates:install    Install an Adobe Developer App Builder template
-  templates:remove     Remove template from registry
-  templates:rollback   Clears all installed templates
-  templates:submit     Submit template for review
-  templates:uninstall  Uninstall an Adobe Developer App Builder template
+DESCRIPTION
+  Discover, install, or uninstall a new template into an existing Adobe Developer App Builder App
 ```
+
+_See code: [src/commands/templates/index.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/index.ts)_
+
+## `aio templates:disco`
+
+Discover App Builder templates to install
+
+```
+USAGE
+  $ aio templates:disco [-v] [-i] [-f publishDate|names|adobeRecommended] [-o asc|desc]
+
+FLAGS
+  -f, --sort-field=<option>  [default: adobeRecommended] which column to sort, use the sort-order flag to specify sort
+                             direction
+                             <options: publishDate|names|adobeRecommended>
+  -i, --interactive          interactive install mode
+  -o, --sort-order=<option>  [default: desc] sort order for a column, use the sort-field flag to specify which column to
+                             sort
+                             <options: asc|desc>
+  -v, --verbose              Verbose output
+
+DESCRIPTION
+  Discover App Builder templates to install
+
+ALIASES
+  $ aio templates:disco
+```
+
 ## `aio templates:discover`
 
 Discover App Builder templates to install
@@ -67,130 +100,337 @@ Discover App Builder templates to install
 USAGE
   $ aio templates:discover [-v] [-i] [-f publishDate|names|adobeRecommended] [-o asc|desc]
 
-OPTIONS
-  -f, --sort-field=<option>  [default: adobeRecommended] which column to sort, use the sort-order flag to specify sort direction
+FLAGS
+  -f, --sort-field=<option>  [default: adobeRecommended] which column to sort, use the sort-order flag to specify sort
+                             direction
                              <options: publishDate|names|adobeRecommended>
   -i, --interactive          interactive install mode
-  -o, --sort-order=<option>  [default: desc] sort order for a column, use the sort-field flag to specify which column to sort
+  -o, --sort-order=<option>  [default: desc] sort order for a column, use the sort-field flag to specify which column to
+                             sort
                              <options: asc|desc>
   -v, --verbose              Verbose output
+
+DESCRIPTION
+  Discover App Builder templates to install
 
 ALIASES
   $ aio templates:disco
 ```
+
+_See code: [src/commands/templates/discover.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/discover.ts)_
+
+## `aio templates:i PATH`
+
+Install an Adobe Developer App Builder template
+
+```
+USAGE
+  $ aio templates:i [PATH] [-v] [-y] [--process-install-config] [--template-options <value>]
+
+ARGUMENTS
+  PATH  path to the template (npm package name, file path, url). See examples
+
+FLAGS
+  -v, --verbose                  Verbose output
+  -y, --yes                      Skip questions, and use all default values
+  --[no-]process-install-config  [default: true] Process the template install.yml configuration file, defaults to true,
+                                 to skip processing install.yml use --no-process-install-config
+  --template-options=<value>     Additional template options, as a base64-encoded json string
+
+DESCRIPTION
+  Install an Adobe Developer App Builder template
+
+ALIASES
+  $ aio templates:i
+
+EXAMPLES
+  $ aio templates:install https://github.com/org/repo
+
+  $ aio templates:install git+https://github.com/org/repo
+
+  $ aio templates:install ssh://github.com/org/repo
+
+  $ aio templates:install git+ssh://github.com/org/repo
+
+  $ aio templates:install file:../relative/path/to/template/folder
+
+  $ aio templates:install file:/absolute/path/to/template/folder
+
+  $ aio templates:install ../relative/path/to/template/folder
+
+  $ aio templates:install /absolute/path/to/template/folder
+
+  $ aio templates:install npm-package-name
+
+  $ aio templates:install npm-package-name@tagOrVersion
+
+  $ aio templates:install @scope/npm-package-name
+
+  $ aio templates:install @scope/npm-package-name@tagOrVersion
+```
+
 ## `aio templates:info`
 
 List all App Builder templates that are installed
 
 ```
 USAGE
-  $ aio templates:info
+  $ aio templates:info [-v] [-y | -j]
 
-OPTIONS
+FLAGS
   -j, --json     output raw json
   -v, --verbose  Verbose output
   -y, --yml      output yml
+
+DESCRIPTION
+  List all App Builder templates that are installed
 ```
-## `aio templates:install`
+
+_See code: [src/commands/templates/info.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/info.ts)_
+
+## `aio templates:install PATH`
 
 Install an Adobe Developer App Builder template
 
 ```
 USAGE
-  $ aio templates:install PATH
+  $ aio templates:install [PATH] [-v] [-y] [--process-install-config] [--template-options <value>]
 
 ARGUMENTS
   PATH  path to the template (npm package name, file path, url). See examples
 
-OPTIONS
-  -v, --verbose  Verbose output
+FLAGS
+  -v, --verbose                  Verbose output
+  -y, --yes                      Skip questions, and use all default values
+  --[no-]process-install-config  [default: true] Process the template install.yml configuration file, defaults to true,
+                                 to skip processing install.yml use --no-process-install-config
+  --template-options=<value>     Additional template options, as a base64-encoded json string
+
+DESCRIPTION
+  Install an Adobe Developer App Builder template
 
 ALIASES
   $ aio templates:i
 
 EXAMPLES
-  aio templates:install https://github.com/org/repo
-  aio templates:install git+https://github.com/org/repo
-  aio templates:install ssh://github.com/org/repo
-  aio templates:install git+ssh://github.com/org/repo
-  aio templates:install file:../relative/path/to/template/folder
-  aio templates:install file:/absolute/path/to/template/folder
-  aio templates:install ../relative/path/to/template/folder
-  aio templates:install /absolute/path/to/template/folder
-  aio templates:install npm-package-name
-  aio templates:install npm-package-name@tagOrVersion
-  aio templates:install @scope/npm-package-name
-  aio templates:install @scope/npm-package-name@tagOrVersion
+  $ aio templates:install https://github.com/org/repo
+
+  $ aio templates:install git+https://github.com/org/repo
+
+  $ aio templates:install ssh://github.com/org/repo
+
+  $ aio templates:install git+ssh://github.com/org/repo
+
+  $ aio templates:install file:../relative/path/to/template/folder
+
+  $ aio templates:install file:/absolute/path/to/template/folder
+
+  $ aio templates:install ../relative/path/to/template/folder
+
+  $ aio templates:install /absolute/path/to/template/folder
+
+  $ aio templates:install npm-package-name
+
+  $ aio templates:install npm-package-name@tagOrVersion
+
+  $ aio templates:install @scope/npm-package-name
+
+  $ aio templates:install @scope/npm-package-name@tagOrVersion
 ```
-## `aio templates:remove`
+
+_See code: [src/commands/templates/install.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/install.ts)_
+
+## `aio templates:r NAME`
 
 Remove an Adobe Developer App Builder template from the Template Registry
 
 ```
 USAGE
-  $ aio templates:remove PACKAGE-NAME
+  $ aio templates:r [NAME] [-v]
 
 ARGUMENTS
-  PACKAGE-NAME  package name of the template
+  NAME  The name of the package implementing the template on npmjs.com
 
-OPTIONS
+FLAGS
   -v, --verbose  Verbose output
+
+DESCRIPTION
+  Remove an Adobe Developer App Builder template from the Template Registry
 
 ALIASES
   $ aio templates:r
+
+EXAMPLES
+  $ aio templates:remove @adobe/app-builder-template
 ```
+
+## `aio templates:remove NAME`
+
+Remove an Adobe Developer App Builder template from the Template Registry
+
+```
+USAGE
+  $ aio templates:remove [NAME] [-v]
+
+ARGUMENTS
+  NAME  The name of the package implementing the template on npmjs.com
+
+FLAGS
+  -v, --verbose  Verbose output
+
+DESCRIPTION
+  Remove an Adobe Developer App Builder template from the Template Registry
+
+ALIASES
+  $ aio templates:r
+
+EXAMPLES
+  $ aio templates:remove @adobe/app-builder-template
+```
+
+_See code: [src/commands/templates/remove.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/remove.ts)_
+
+## `aio templates:rollb`
+
+Clears all installed templates
+
+```
+USAGE
+  $ aio templates:rollb [-v] [-i] [-l] [-c]
+
+FLAGS
+  -c, --[no-]confirm  confirmation needed for clear (defaults to true)
+  -i, --interactive   interactive clear mode
+  -l, --list          list templates that will be uninstalled
+  -v, --verbose       Verbose output
+
+DESCRIPTION
+  Clears all installed templates
+
+ALIASES
+  $ aio templates:rollb
+```
+
 ## `aio templates:rollback`
 
 Clears all installed templates
 
 ```
 USAGE
-  $ aio templates:rollback
+  $ aio templates:rollback [-v] [-i] [-l] [-c]
 
-OPTIONS
+FLAGS
   -c, --[no-]confirm  confirmation needed for clear (defaults to true)
   -i, --interactive   interactive clear mode
   -l, --list          list templates that will be uninstalled
   -v, --verbose       Verbose output
 
+DESCRIPTION
+  Clears all installed templates
+
 ALIASES
   $ aio templates:rollb
 ```
-## `aio templates:submit`
 
-Submit an Adobe Developer App Builder template
+_See code: [src/commands/templates/rollback.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/rollback.ts)_
+
+## `aio templates:s NAME GITHUBREPOURL`
+
+Install an Adobe Developer App Builder template
 
 ```
 USAGE
-  $ aio templates:submit PACKAGE-NAME GITHUB-URL
+  $ aio templates:s [NAME] [GITHUBREPOURL] [-v]
 
 ARGUMENTS
-  PACKAGE-NAME  package name of the template
-  GITHUB-URL    URL of github repository
+  NAME           The name of the package implementing the template on npmjs.com
+  GITHUBREPOURL  A link to the Github repository containing the package's source code
 
-OPTIONS
+FLAGS
   -v, --verbose  Verbose output
+
+DESCRIPTION
+  Install an Adobe Developer App Builder template
 
 ALIASES
   $ aio templates:s
+
+EXAMPLES
+  $ aio templates:submit @adobe/app-builder-template https://github.com/adobe/app-builder-template
 ```
-## `aio templates:uninstall`
+
+## `aio templates:submit NAME GITHUBREPOURL`
+
+Install an Adobe Developer App Builder template
+
+```
+USAGE
+  $ aio templates:submit [NAME] [GITHUBREPOURL] [-v]
+
+ARGUMENTS
+  NAME           The name of the package implementing the template on npmjs.com
+  GITHUBREPOURL  A link to the Github repository containing the package's source code
+
+FLAGS
+  -v, --verbose  Verbose output
+
+DESCRIPTION
+  Install an Adobe Developer App Builder template
+
+ALIASES
+  $ aio templates:s
+
+EXAMPLES
+  $ aio templates:submit @adobe/app-builder-template https://github.com/adobe/app-builder-template
+```
+
+_See code: [src/commands/templates/submit.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/submit.ts)_
+
+## `aio templates:un PACKAGE-NAME`
 
 Uninstall an Adobe Developer App Builder template
 
 ```
 USAGE
-  $ aio templates:uninstall PACKAGE-NAME
+  $ aio templates:un [PACKAGE-NAME] [-v]
 
 ARGUMENTS
   PACKAGE-NAME  package name of the template
 
-OPTIONS
+FLAGS
   -v, --verbose  Verbose output
+
+DESCRIPTION
+  Uninstall an Adobe Developer App Builder template
 
 ALIASES
   $ aio templates:un
 ```
+
+## `aio templates:uninstall PACKAGE-NAME`
+
+Uninstall an Adobe Developer App Builder template
+
+```
+USAGE
+  $ aio templates:uninstall [PACKAGE-NAME] [-v]
+
+ARGUMENTS
+  PACKAGE-NAME  package name of the template
+
+FLAGS
+  -v, --verbose  Verbose output
+
+DESCRIPTION
+  Uninstall an Adobe Developer App Builder template
+
+ALIASES
+  $ aio templates:un
+```
+
+_See code: [src/commands/templates/uninstall.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/uninstall.ts)_
+<!-- commandsstop -->
+
 # Contributing
 
 Contributions are welcomed! Read the [Contributing Guide](./CONTRIBUTING.md) for more information.

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -55,7 +55,8 @@ class InstallCommand extends BaseCommand {
           // do not prompt for overwrites
           force: true,
           // do not install dependencies as they have been installed already
-          'skip-install': true
+          'skip-install': true,
+          ...flags['template-options']
         }
       })
     spinner.succeed(`Finished running template ${templateName}`)
@@ -147,6 +148,19 @@ InstallCommand.flags = {
     description: '[default: true] Process the template install.yml configuration file, defaults to true, to skip processing install.yml use --no-process-install-config',
     default: true,
     allowNo: true
+  }),
+  'template-options': Flags.string({
+    description: 'Additional template options, as a base64-encoded json string',
+    parse: input => {
+      try {
+        const decoded = Buffer.from(input, 'base64').toString('utf8')
+        aioLogger.debug(`--template-options: ${input} decoded as ${decoded}`)
+        return JSON.parse(decoded)
+      } catch (e) {
+        throw new Error(`--template-options: ${input} is not a base64 encoded JSON object.`)
+      }
+    },
+    default: {}
   })
 }
 

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -49,7 +49,7 @@ class InstallCommand extends BaseCommand {
     env.options = { skipInstall: true } // do not install dependencies as they have been installed already
     spinner.info(`Running template ${templateName}`)
 
-    const templateOptions = flags['template-options']
+    const templateOptions = flags['template-options'] || {}
     const defaultOptions = {
       'skip-prompt': flags.yes,
       // do not prompt for overwrites
@@ -165,8 +165,7 @@ InstallCommand.flags = {
       } catch (e) {
         throw new Error(`--template-options: ${input} is not a base64 encoded JSON object.`)
       }
-    },
-    default: {}
+    }
   })
 }
 

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -46,19 +46,25 @@ class InstallCommand extends BaseCommand {
     aioLogger.debug(`templateName: ${templateName}`)
 
     const env = yeoman.createEnv()
-    env.register(require.resolve(templateName, { paths: [process.cwd()] }), 'template-to-run')
     spinner.info(`Running template ${templateName}`)
-    await env.run('template-to-run',
-      {
-        options: {
-          'skip-prompt': flags.yes,
-          // do not prompt for overwrites
-          force: true,
-          // do not install dependencies as they have been installed already
-          'skip-install': true,
-          ...flags['template-options']
-        }
-      })
+
+    const templateOptions = flags['template-options']
+    const defaultOptions = {
+      'skip-prompt': flags.yes,
+      // do not prompt for overwrites
+      force: true,
+      // do not install dependencies as they have been installed already
+      'skip-install': true
+    }
+
+    aioLogger.debug(`defaultOptions: ${JSON.stringify(defaultOptions)}`)
+    aioLogger.debug(`flags['template-options']: ${JSON.stringify(templateOptions)}`)
+
+    const templatePath = require.resolve(templateName, { paths: [process.cwd()] })
+    const gen = env.instantiate(require(templatePath), {
+      options: { ...defaultOptions, ...templateOptions }
+    })
+    await env.runGenerator(gen)
     spinner.succeed(`Finished running template ${templateName}`)
 
     if (flags['process-install-config']) {

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -46,15 +46,15 @@ class InstallCommand extends BaseCommand {
     aioLogger.debug(`templateName: ${templateName}`)
 
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true } // do not install dependencies as they have been installed already
     spinner.info(`Running template ${templateName}`)
 
     const templateOptions = flags['template-options']
     const defaultOptions = {
       'skip-prompt': flags.yes,
       // do not prompt for overwrites
-      force: true,
-      // do not install dependencies as they have been installed already
-      'skip-install': true
+      force: true
+      // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
     }
 
     aioLogger.debug(`defaultOptions: ${JSON.stringify(defaultOptions)}`)

--- a/test/commands/templates/install.test.js
+++ b/test/commands/templates/install.test.js
@@ -45,10 +45,17 @@ Ims.getToken.mockResolvedValue('bowling')
 jest.mock('yeoman-environment')
 const yeoman = require('yeoman-environment')
 const yeomanEnvInstantiate = jest.fn()
-yeoman.createEnv.mockReturnValue({
+const yeomanEnvOptionsGet = jest.fn()
+const yeomanEnvOptionsSet = jest.fn()
+const createEnvReturnValue = {
   instantiate: yeomanEnvInstantiate,
   runGenerator: jest.fn()
+}
+Object.defineProperty(createEnvReturnValue, 'options', {
+  get: yeomanEnvOptionsGet,
+  set: yeomanEnvOptionsSet
 })
+yeoman.createEnv.mockReturnValue(createEnvReturnValue)
 
 jest.mock('my-adobe-template-path', () => ({}), { virtual: true })
 jest.mock('my-adobe-package-path', () => ({}), { virtual: true })
@@ -131,10 +138,11 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(5)
+    expect.assertions(6)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', argPath])
-    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true, 'skip-install': true } })
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -155,10 +163,11 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(5)
+    expect.assertions(6)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
-    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true, 'skip-install': true } })
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -179,10 +188,11 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(5)
+    expect.assertions(6)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
-    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': true, force: true, 'skip-install': true } })
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': true, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -203,10 +213,11 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(5)
+    expect.assertions(6)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
-    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true, 'skip-install': true } })
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
     expect(mockTemplateHandlerInstance.installTemplate).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -230,10 +241,11 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(5)
+    expect.assertions(6)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
-    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true, 'skip-install': true } })
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).not.toHaveBeenCalled()
   })
@@ -271,10 +283,11 @@ describe('template-options', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(5)
+    expect.assertions(6)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', argPath])
-    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true, 'skip-install': true } })
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [

--- a/test/commands/templates/install.test.js
+++ b/test/commands/templates/install.test.js
@@ -109,7 +109,6 @@ test('flags', () => {
 
   expect(TheCommand.flags['template-options']).toBeDefined()
   expect(TheCommand.flags['template-options'].type).toBe('option')
-  expect(TheCommand.flags['template-options'].default).toEqual({})
 })
 
 test('args', async () => {


### PR DESCRIPTION
## Description

1. Feature ACNA-1728 - add template options support to app-templates plugin (install command) 79c49f18  6eece445
2. Fix ACNA-1732 - yeoman run skip-install work-around (see https://github.com/adobe/aio-cli-plugin-app/pull/561) 77bdb787
3. Fix running of the template/generator not getting passed options: 59323244
4. Fix README.md (auto-gen the docs) 1802bbfd

## How Has This Been Tested?

- npm test
- cli test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
