### PR TITLE
DEVX-2487: [Issue] Template dependencies are not installed during `aio templates install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ DESCRIPTION
   Discover, install, or uninstall a new template into an existing Adobe Developer App Builder App
 ```
 
-_See code: [src/commands/templates/index.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/index.ts)_
+_See code: [src/commands/templates/index.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/index.ts)_
 
 ## `aio templates:disco`
 
@@ -117,7 +117,7 @@ ALIASES
   $ aio templates:disco
 ```
 
-_See code: [src/commands/templates/discover.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/discover.ts)_
+_See code: [src/commands/templates/discover.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/discover.ts)_
 
 ## `aio templates:i PATH`
 
@@ -125,7 +125,7 @@ Install an Adobe Developer App Builder template
 
 ```
 USAGE
-  $ aio templates:i [PATH] [-v] [-y] [--process-install-config] [--template-options <value>]
+  $ aio templates:i [PATH] [-v] [-y] [--install] [--process-install-config] [--template-options <value>]
 
 ARGUMENTS
   PATH  path to the template (npm package name, file path, url). See examples
@@ -133,6 +133,7 @@ ARGUMENTS
 FLAGS
   -v, --verbose                  Verbose output
   -y, --yes                      Skip questions, and use all default values
+  --[no-]install                 [default: true] Run npm installation after files are created
   --[no-]process-install-config  [default: true] Process the template install.yml configuration file, defaults to true,
                                  to skip processing install.yml use --no-process-install-config
   --template-options=<value>     Additional template options, as a base64-encoded json string
@@ -186,7 +187,7 @@ DESCRIPTION
   List all App Builder templates that are installed
 ```
 
-_See code: [src/commands/templates/info.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/info.ts)_
+_See code: [src/commands/templates/info.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/info.ts)_
 
 ## `aio templates:install PATH`
 
@@ -194,7 +195,7 @@ Install an Adobe Developer App Builder template
 
 ```
 USAGE
-  $ aio templates:install [PATH] [-v] [-y] [--process-install-config] [--template-options <value>]
+  $ aio templates:install [PATH] [-v] [-y] [--install] [--process-install-config] [--template-options <value>]
 
 ARGUMENTS
   PATH  path to the template (npm package name, file path, url). See examples
@@ -202,6 +203,7 @@ ARGUMENTS
 FLAGS
   -v, --verbose                  Verbose output
   -y, --yes                      Skip questions, and use all default values
+  --[no-]install                 [default: true] Run npm installation after files are created
   --[no-]process-install-config  [default: true] Process the template install.yml configuration file, defaults to true,
                                  to skip processing install.yml use --no-process-install-config
   --template-options=<value>     Additional template options, as a base64-encoded json string
@@ -238,7 +240,7 @@ EXAMPLES
   $ aio templates:install @scope/npm-package-name@tagOrVersion
 ```
 
-_See code: [src/commands/templates/install.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/install.ts)_
+_See code: [src/commands/templates/install.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/install.ts)_
 
 ## `aio templates:r NAME`
 
@@ -288,7 +290,7 @@ EXAMPLES
   $ aio templates:remove @adobe/app-builder-template
 ```
 
-_See code: [src/commands/templates/remove.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/remove.ts)_
+_See code: [src/commands/templates/remove.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/remove.ts)_
 
 ## `aio templates:rollb`
 
@@ -332,7 +334,7 @@ ALIASES
   $ aio templates:rollb
 ```
 
-_See code: [src/commands/templates/rollback.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/rollback.ts)_
+_See code: [src/commands/templates/rollback.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/rollback.ts)_
 
 ## `aio templates:s NAME GITHUBREPOURL`
 
@@ -384,7 +386,7 @@ EXAMPLES
   $ aio templates:submit @adobe/app-builder-template https://github.com/adobe/app-builder-template
 ```
 
-_See code: [src/commands/templates/submit.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/submit.ts)_
+_See code: [src/commands/templates/submit.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/submit.ts)_
 
 ## `aio templates:un PACKAGE-NAME`
 
@@ -428,7 +430,7 @@ ALIASES
   $ aio templates:un
 ```
 
-_See code: [src/commands/templates/uninstall.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.6/src/commands/templates/uninstall.ts)_
+_See code: [src/commands/templates/uninstall.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/uninstall.ts)_
 <!-- commandsstop -->
 
 # Contributing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-cli-plugin-app-templates",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "Discover, Install, Uninstall, Submit, and Remove Adobe App Builder templates",
   "repository": {
     "type": "git",

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -46,7 +46,7 @@ class InstallCommand extends BaseCommand {
     aioLogger.debug(`templateName: ${templateName}`)
 
     const env = yeoman.createEnv()
-    env.options = { skipInstall: true } // do not install dependencies as they have been installed already
+    env.options = { skipInstall: !flags.install }
     spinner.info(`Running template ${templateName}`)
 
     const templateOptions = flags['template-options'] || {}
@@ -149,6 +149,11 @@ InstallCommand.flags = {
     description: 'Skip questions, and use all default values',
     default: false,
     char: 'y'
+  }),
+  install: Flags.boolean({
+    description: '[default: true] Run npm installation after files are created',
+    default: true,
+    allowNo: true
   }),
   'process-install-config': Flags.boolean({
     description: '[default: true] Process the template install.yml configuration file, defaults to true, to skip processing install.yml use --no-process-install-config',

--- a/test/commands/templates/install.test.js
+++ b/test/commands/templates/install.test.js
@@ -102,6 +102,11 @@ test('flags', () => {
   expect(TheCommand.flags.yes.type).toBe('boolean')
   expect(TheCommand.flags.yes.default).toBe(false)
 
+  expect(TheCommand.flags.install).toBeDefined()
+  expect(TheCommand.flags.install.type).toBe('boolean')
+  expect(TheCommand.flags.install.default).toBe(true)
+  expect(TheCommand.flags.install.allowNo).toBe(true)
+
   expect(TheCommand.flags['process-install-config']).toBeDefined()
   expect(TheCommand.flags['process-install-config'].type).toBe('boolean')
   expect(TheCommand.flags['process-install-config'].default).toBe(true)
@@ -141,7 +146,7 @@ describe('run', () => {
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', argPath])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
-    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -166,7 +171,7 @@ describe('run', () => {
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
-    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -191,7 +196,57 @@ describe('run', () => {
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': true, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
+    expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(writeObjectToPackageJson).toBeCalledWith({
+      [TEMPLATE_PACKAGE_JSON_KEY]: [
+        templateName
+      ]
+    })
+  })
+
+  test('install from package name skipping running npm installation', async () => {
+    const templateName = 'my-adobe-package'
+    command.argv = ['--no-install', templateName]
+
+    readPackageJson.mockResolvedValueOnce({
+      dependencies: {
+        [templateName]: '^1.0.0'
+      }
+    })
+
+    getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
+
+    expect.assertions(6)
+    await expect(command.run()).resolves.toBeUndefined()
+    expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
+    expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(writeObjectToPackageJson).toBeCalledWith({
+      [TEMPLATE_PACKAGE_JSON_KEY]: [
+        templateName
+      ]
+    })
+  })
+
+  test('install from package name with --install', async () => {
+    const templateName = 'my-adobe-package'
+    command.argv = ['--install', templateName]
+
+    readPackageJson.mockResolvedValueOnce({
+      dependencies: {
+        [templateName]: '^1.0.0'
+      }
+    })
+
+    getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
+
+    expect.assertions(6)
+    await expect(command.run()).resolves.toBeUndefined()
+    expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
+    expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -216,7 +271,7 @@ describe('run', () => {
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
-    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
@@ -244,7 +299,7 @@ describe('run', () => {
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
-    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).not.toHaveBeenCalled()
   })
@@ -286,7 +341,7 @@ describe('template-options', () => {
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', argPath])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
-    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
+    expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For existing App Builder projects `aio templates install` skips installing a template dependencies. I changed `aio templates install` to install them by default. Also to be in sync with `aio app init --[no-]install`, I added the `--[no-]install` flag to `aio templates install` as well, the similar behavior.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DEVX-2487

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- npm test
- running `aio templates install --[no-]install`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
