### PR TITLE
oclif readme --no-aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jest-haste-map": "^24.5.0",
     "jest-junit": "^6.0.0",
     "jest-resolve": "^24.5.0",
-    "oclif": "^3.0.1",
+    "oclif": "^3.2.0",
     "stdout-stderr": "^0.1.9",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.2"
@@ -71,7 +71,7 @@
     "pretest": "eslint src test",
     "test": "npm run unit-tests",
     "unit-tests": "jest --ci",
-    "prepack": "oclif manifest && oclif readme",
+    "prepack": "oclif manifest && oclif readme --no-aliases",
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif readme && git add README.md",
     "lint:check": "eslint --ext .js .",


### PR DESCRIPTION
The new oclif README doc generator was listing the aliases as well as commands (which just clutters up the README docs), now there is a new flag --no-aliases. 