### PR TITLE
DEVX-2502: feature request: aio app init --no-login and required services

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ DESCRIPTION
   Discover, install, or uninstall a new template into an existing Adobe Developer App Builder App
 ```
 
-_See code: [src/commands/templates/index.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/index.ts)_
+_See code: [src/commands/templates/index.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/index.ts)_
 
 ## `aio templates:disco`
 
@@ -117,7 +117,7 @@ ALIASES
   $ aio templates:disco
 ```
 
-_See code: [src/commands/templates/discover.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/discover.ts)_
+_See code: [src/commands/templates/discover.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/discover.ts)_
 
 ## `aio templates:i PATH`
 
@@ -145,29 +145,29 @@ ALIASES
   $ aio templates:i
 
 EXAMPLES
-  $ aio templates:install https://github.com/org/repo
+  $ aio templates install https://github.com/org/repo
 
-  $ aio templates:install git+https://github.com/org/repo
+  $ aio templates install git+https://github.com/org/repo
 
-  $ aio templates:install ssh://github.com/org/repo
+  $ aio templates install ssh://github.com/org/repo
 
-  $ aio templates:install git+ssh://github.com/org/repo
+  $ aio templates install git+ssh://github.com/org/repo
 
-  $ aio templates:install file:../relative/path/to/template/folder
+  $ aio templates install file:../relative/path/to/template/folder
 
-  $ aio templates:install file:/absolute/path/to/template/folder
+  $ aio templates install file:/absolute/path/to/template/folder
 
-  $ aio templates:install ../relative/path/to/template/folder
+  $ aio templates install ../relative/path/to/template/folder
 
-  $ aio templates:install /absolute/path/to/template/folder
+  $ aio templates install /absolute/path/to/template/folder
 
-  $ aio templates:install npm-package-name
+  $ aio templates install npm-package-name
 
-  $ aio templates:install npm-package-name@tagOrVersion
+  $ aio templates install npm-package-name@tagOrVersion
 
-  $ aio templates:install @scope/npm-package-name
+  $ aio templates install @scope/npm-package-name
 
-  $ aio templates:install @scope/npm-package-name@tagOrVersion
+  $ aio templates install @scope/npm-package-name@tagOrVersion
 ```
 
 ## `aio templates:info`
@@ -176,18 +176,19 @@ List all App Builder templates that are installed
 
 ```
 USAGE
-  $ aio templates:info [-v] [-y | -j]
+  $ aio templates:info [-v] [-y | -j] [-s]
 
 FLAGS
-  -j, --json     output raw json
-  -v, --verbose  Verbose output
-  -y, --yml      output yml
+  -j, --json               output raw json
+  -s, --required-services  includes services required by a template in the output
+  -v, --verbose            Verbose output
+  -y, --yml                output yml
 
 DESCRIPTION
   List all App Builder templates that are installed
 ```
 
-_See code: [src/commands/templates/info.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/info.ts)_
+_See code: [src/commands/templates/info.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/info.ts)_
 
 ## `aio templates:install PATH`
 
@@ -215,32 +216,32 @@ ALIASES
   $ aio templates:i
 
 EXAMPLES
-  $ aio templates:install https://github.com/org/repo
+  $ aio templates install https://github.com/org/repo
 
-  $ aio templates:install git+https://github.com/org/repo
+  $ aio templates install git+https://github.com/org/repo
 
-  $ aio templates:install ssh://github.com/org/repo
+  $ aio templates install ssh://github.com/org/repo
 
-  $ aio templates:install git+ssh://github.com/org/repo
+  $ aio templates install git+ssh://github.com/org/repo
 
-  $ aio templates:install file:../relative/path/to/template/folder
+  $ aio templates install file:../relative/path/to/template/folder
 
-  $ aio templates:install file:/absolute/path/to/template/folder
+  $ aio templates install file:/absolute/path/to/template/folder
 
-  $ aio templates:install ../relative/path/to/template/folder
+  $ aio templates install ../relative/path/to/template/folder
 
-  $ aio templates:install /absolute/path/to/template/folder
+  $ aio templates install /absolute/path/to/template/folder
 
-  $ aio templates:install npm-package-name
+  $ aio templates install npm-package-name
 
-  $ aio templates:install npm-package-name@tagOrVersion
+  $ aio templates install npm-package-name@tagOrVersion
 
-  $ aio templates:install @scope/npm-package-name
+  $ aio templates install @scope/npm-package-name
 
-  $ aio templates:install @scope/npm-package-name@tagOrVersion
+  $ aio templates install @scope/npm-package-name@tagOrVersion
 ```
 
-_See code: [src/commands/templates/install.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/install.ts)_
+_See code: [src/commands/templates/install.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/install.ts)_
 
 ## `aio templates:r NAME`
 
@@ -290,7 +291,7 @@ EXAMPLES
   $ aio templates:remove @adobe/app-builder-template
 ```
 
-_See code: [src/commands/templates/remove.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/remove.ts)_
+_See code: [src/commands/templates/remove.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/remove.ts)_
 
 ## `aio templates:rollb`
 
@@ -334,7 +335,7 @@ ALIASES
   $ aio templates:rollb
 ```
 
-_See code: [src/commands/templates/rollback.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/rollback.ts)_
+_See code: [src/commands/templates/rollback.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/rollback.ts)_
 
 ## `aio templates:s NAME GITHUBREPOURL`
 
@@ -386,7 +387,7 @@ EXAMPLES
   $ aio templates:submit @adobe/app-builder-template https://github.com/adobe/app-builder-template
 ```
 
-_See code: [src/commands/templates/submit.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/submit.ts)_
+_See code: [src/commands/templates/submit.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/submit.ts)_
 
 ## `aio templates:un PACKAGE-NAME`
 
@@ -430,7 +431,7 @@ ALIASES
   $ aio templates:un
 ```
 
-_See code: [src/commands/templates/uninstall.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.0.0-beta.11/src/commands/templates/uninstall.ts)_
+_See code: [src/commands/templates/uninstall.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/1.2.0/src/commands/templates/uninstall.ts)_
 <!-- commandsstop -->
 
 # Contributing

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@adobe/aio-cli-lib-app-config": "^0.2.2",
     "@adobe/aio-cli-lib-console": "^4.0.0",
-    "@adobe/aio-lib-console-project-installation": "^2.0.2",
+    "@adobe/aio-lib-console-project-installation": "^2.1.0",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-logging": "^1.1.0",
     "@adobe/aio-lib-env": "^2.0.0",

--- a/src/commands/templates/info.js
+++ b/src/commands/templates/info.js
@@ -14,7 +14,7 @@ const yaml = require('js-yaml')
 const chalk = require('chalk')
 const BaseCommand = require('../../BaseCommand')
 const { readPackageJson, getNpmLocalVersion, TEMPLATE_PACKAGE_JSON_KEY } = require('../../lib/npm-helper')
-const { getTemplateRequiredServices } = require('../../lib/template-helper')
+const { getTemplateRequiredServiceNames } = require('../../lib/template-helper')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app-templates:templates:info', { provider: 'debug' })
 
 class InfoCommand extends BaseCommand {
@@ -46,7 +46,7 @@ class InfoCommand extends BaseCommand {
         const version = await getNpmLocalVersion(name)
         const info = { name, version, spec }
         if (flags['required-services']) {
-          info['required-services'] = this.getTemplateRequiredServices(name)
+          info['required-services'] = getTemplateRequiredServiceNames(name)
         }
         templates.push(info)
       } catch (e) {
@@ -67,26 +67,6 @@ class InfoCommand extends BaseCommand {
     } else {
       this.log('no app templates are installed')
     }
-  }
-
-  /**
-   * Returns a list of services required by a template.
-   * For example:
-   * ['runtime', 'GraphQLServiceSDK', 'AssetComputeSDK']
-   *
-   * @param {string} npmPackageName a npm package name
-   * @returns {Array} a list of services required by a template
-   */
-  getTemplateRequiredServices (npmPackageName) {
-    const info = getTemplateRequiredServices(npmPackageName)
-    const templateRequiredServices = []
-    if (info.runtime) {
-      templateRequiredServices.push('runtime')
-    }
-    for (const api of info.apis) {
-      templateRequiredServices.push(api.code)
-    }
-    return templateRequiredServices
   }
 }
 

--- a/src/commands/templates/info.js
+++ b/src/commands/templates/info.js
@@ -14,6 +14,7 @@ const yaml = require('js-yaml')
 const chalk = require('chalk')
 const BaseCommand = require('../../BaseCommand')
 const { readPackageJson, getNpmLocalVersion, TEMPLATE_PACKAGE_JSON_KEY } = require('../../lib/npm-helper')
+const { getTemplateRequiredServices } = require('../../lib/template-helper')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app-templates:templates:info', { provider: 'debug' })
 
 class InfoCommand extends BaseCommand {
@@ -21,8 +22,12 @@ class InfoCommand extends BaseCommand {
     return `${indent.repeat(count)}${string}`
   }
 
-  printTemplate (template, count = 0, indent = ' ') {
-    this.log(this.indentString(`${template.name}@${template.spec} (${chalk.gray(template.version)})`, count, indent))
+  printTemplate (template, printRequiredServices = false, count = 0, indent = ' ') {
+    let output = `${template.name}@${template.spec} (${chalk.gray(template.version)})`
+    if (printRequiredServices) {
+      output += ' Required services: ' + (template['required-services'].length > 0 ? template['required-services'].join(', ') : 'NONE')
+    }
+    this.log(this.indentString(output, count, indent))
   }
 
   async run () {
@@ -39,7 +44,11 @@ class InfoCommand extends BaseCommand {
       const spec = packageJson.dependencies[name] || 'unknown'
       try {
         const version = await getNpmLocalVersion(name)
-        templates.push({ name, version, spec })
+        const info = { name, version, spec }
+        if (flags['required-services']) {
+          info['required-services'] = this.getTemplateRequiredServices(name)
+        }
+        templates.push(info)
       } catch (e) {
         // might not be installed yet, just put a dummy version
         aioLogger.debug(`template not found (error or not npm installed yet), using 'unknown' version: ${e}`)
@@ -53,11 +62,31 @@ class InfoCommand extends BaseCommand {
       this.log(JSON.stringify(templates, null, 2))
     } else if (templates.length > 0) {
       for (const template of templates) {
-        this.printTemplate(template)
+        this.printTemplate(template, flags['required-services'])
       }
     } else {
       this.log('no app templates are installed')
     }
+  }
+
+  /**
+   * Returns a list of services required by a template.
+   * For example:
+   * ['runtime', 'GraphQLServiceSDK', 'AssetComputeSDK']
+   *
+   * @param {string} npmPackageName a npm package name
+   * @returns {Array} a list of services required by a template
+   */
+  getTemplateRequiredServices (npmPackageName) {
+    const info = getTemplateRequiredServices(npmPackageName)
+    const templateRequiredServices = []
+    if (info.runtime) {
+      templateRequiredServices.push('runtime')
+    }
+    for (const api of info.apis) {
+      templateRequiredServices.push(api.code)
+    }
+    return templateRequiredServices
   }
 }
 
@@ -75,6 +104,11 @@ InfoCommand.flags = {
     description: 'output yml',
     default: false,
     exclusive: ['json']
+  }),
+  'required-services': Flags.boolean({
+    char: 's',
+    description: 'includes services required by a template in the output',
+    default: false
   })
 }
 

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -13,6 +13,7 @@
 const BaseCommand = require('../../BaseCommand')
 const { runScript } = require('../../lib/helper')
 const { writeObjectToPackageJson, readPackageJson, getNpmDependency, processNpmPackageSpec, TEMPLATE_PACKAGE_JSON_KEY } = require('../../lib/npm-helper')
+const { getTemplateRequiredServiceNames } = require('../../lib/template-helper')
 const ora = require('ora')
 const yeoman = require('yeoman-environment')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app-templates:templates:install', { provider: 'debug' })
@@ -83,10 +84,13 @@ class InstallCommand extends BaseCommand {
     }
 
     if (!flags['process-install-config']) {
-      this.log('\n')
-      this.log('Please check the following template dependencies, if any, that should be met by Adobe Console project workspaces.')
-      await this.config.runCommand('templates:info')
-      this.log('\n')
+      const templateRequiredServiceNames = getTemplateRequiredServiceNames(templateName)
+      if (templateRequiredServiceNames.length > 0) {
+        this.log('\n')
+        this.log('Please check the following template dependencies, that should be met by Adobe Console project workspaces:')
+        this.log(templateRequiredServiceNames.join(', '))
+        this.log('\n')
+      }
     }
   }
 

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -81,6 +81,13 @@ class InstallCommand extends BaseCommand {
     } else {
       aioLogger.debug(`duplicate template, skipping: ${templateName}`)
     }
+
+    if (!flags['process-install-config']) {
+      this.log('\n')
+      this.log('Please check the following template dependencies, if any, that should be met by Adobe Console project workspaces.')
+      await this.config.runCommand('templates:info')
+      this.log('\n')
+    }
   }
 
   /**

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -86,10 +86,7 @@ class InstallCommand extends BaseCommand {
     if (!flags['process-install-config']) {
       const templateRequiredServiceNames = getTemplateRequiredServiceNames(templateName)
       if (templateRequiredServiceNames.length > 0) {
-        this.log('\n')
-        this.log('Please check the following template dependencies, that should be met by Adobe Console project workspaces:')
-        this.log(templateRequiredServiceNames.join(', '))
-        this.log('\n')
+        this.log(`\n! Please check the following template dependencies, that should be met by Adobe Console project workspaces: ${templateRequiredServiceNames.join(', ')}\n`)
       }
     }
   }

--- a/src/lib/template-helper.js
+++ b/src/lib/template-helper.js
@@ -31,6 +31,27 @@ function getTemplateRequiredServices (npmPackageName, dir = process.cwd()) {
   return info
 }
 
+/**
+ * Returns a list of service names required by a template.
+ * For example:
+ * ['runtime', 'GraphQLServiceSDK', 'AssetComputeSDK']
+ *
+ * @param {string} npmPackageName a npm package name
+ * @returns {Array} a list of service names required by a template
+ */
+function getTemplateRequiredServiceNames (npmPackageName) {
+  const info = getTemplateRequiredServices(npmPackageName)
+  const templateRequiredServiceNames = []
+  if (info.runtime) {
+    templateRequiredServiceNames.push('runtime')
+  }
+  for (const api of info.apis) {
+    templateRequiredServiceNames.push(api.code)
+  }
+  return templateRequiredServiceNames
+}
+
 module.exports = {
-  getTemplateRequiredServices
+  getTemplateRequiredServices,
+  getTemplateRequiredServiceNames
 }

--- a/src/lib/template-helper.js
+++ b/src/lib/template-helper.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Adobe Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app-templates:lib-template-helper', { provider: 'debug' })
+const templateHandler = require('@adobe/aio-lib-console-project-installation')
+const path = require('path')
+
+/**
+ * Returns services required by a template.
+ * For example:
+ * { runtime: true, apis: [{ code: 'GraphQLServiceSDK' }, { code: 'AssetComputeSDK' }] }
+ *
+ * @param {string} npmPackageName a npm package name
+ * @param {string} dir a root path of where node_modules is
+ * @returns {object} an object with properties `runtime` and `apis`
+ */
+function getTemplateRequiredServices (npmPackageName, dir = process.cwd()) {
+  const templateConfigurationFile = path.join(dir, 'node_modules', npmPackageName, 'install.yml')
+  aioLogger.debug(`Getting services required by a template from ${templateConfigurationFile} ...`)
+  const info = templateHandler.getTemplateRequiredServices(templateConfigurationFile)
+  aioLogger.debug(`Retrieved services required by a template: ${JSON.stringify(info, null, 2)}`)
+  return info
+}
+
+module.exports = {
+  getTemplateRequiredServices
+}

--- a/test/commands/templates/info.test.js
+++ b/test/commands/templates/info.test.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 const TheCommand = require('../../../src/commands/templates/info')
 const BaseCommand = require('../../../src/BaseCommand')
 const { TEMPLATE_PACKAGE_JSON_KEY, getNpmLocalVersion, readPackageJson } = require('../../../src/lib/npm-helper')
-const { getTemplateRequiredServices } = require('../../../src/lib/template-helper')
+const { getTemplateRequiredServiceNames } = require('../../../src/lib/template-helper')
 const { stdout } = require('stdout-stderr')
 
 jest.mock('../../../src/lib/npm-helper', () => {
@@ -230,9 +230,9 @@ describe('instance methods', () => {
         .mockResolvedValueOnce('1.0.1')
         .mockResolvedValueOnce('2.0.1')
 
-      getTemplateRequiredServices
-        .mockReturnValueOnce({ runtime: false, apis: [] })
-        .mockReturnValueOnce({ runtime: true, apis: [{ code: 'GraphQLServiceSDK' }, { code: 'AssetComputeSDK' }] })
+      getTemplateRequiredServiceNames
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce(['runtime', 'GraphQLServiceSDK', 'AssetComputeSDK'])
 
       command.argv = ['--required-services']
       return command.run()

--- a/test/commands/templates/install.test.js
+++ b/test/commands/templates/install.test.js
@@ -75,6 +75,9 @@ let command
 
 beforeEach(() => {
   command = new TheCommand([])
+  command.config = {
+    runCommand: jest.fn()
+  }
   jest.clearAllMocks()
 })
 
@@ -142,12 +145,13 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', argPath])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(command.config.runCommand).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
         templateName
@@ -167,12 +171,13 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(command.config.runCommand).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
         templateName
@@ -192,12 +197,13 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': true, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(command.config.runCommand).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
         templateName
@@ -217,12 +223,13 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: true })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(command.config.runCommand).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
         templateName
@@ -242,12 +249,13 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(command.config.runCommand).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
         templateName
@@ -267,12 +275,13 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).not.toBeCalled()
+    expect(command.config.runCommand).toBeCalledWith('templates:info')
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
         templateName
@@ -295,12 +304,13 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(command.config.runCommand).not.toBeCalled()
     expect(writeObjectToPackageJson).not.toHaveBeenCalled()
   })
 
@@ -337,12 +347,13 @@ describe('template-options', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(6)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', argPath])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toBeCalledWith({ skipInstall: false })
     expect(mockTemplateHandlerInstance.installTemplate).toBeCalledWith('org-id', 'project-id')
+    expect(command.config.runCommand).not.toBeCalled()
     expect(writeObjectToPackageJson).toBeCalledWith({
       [TEMPLATE_PACKAGE_JSON_KEY]: [
         templateName

--- a/test/commands/templates/install.test.js
+++ b/test/commands/templates/install.test.js
@@ -277,7 +277,7 @@ describe('run', () => {
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
     getTemplateRequiredServiceNames.mockReturnValueOnce(['runtime', 'GraphQLServiceSDK', 'AssetComputeSDK'])
 
-    expect.assertions(9)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
@@ -289,8 +289,7 @@ describe('run', () => {
         templateName
       ]
     })
-    expect(stdout.output).toMatch('Please check the following template dependencies, that should be met by Adobe Console project workspaces:')
-    expect(stdout.output).toMatch('runtime, GraphQLServiceSDK, AssetComputeSDK')
+    expect(stdout.output).toMatch('! Please check the following template dependencies, that should be met by Adobe Console project workspaces: runtime, GraphQLServiceSDK, AssetComputeSDK')
   })
 
   test('install from package name skipping processing install.yml with no template services', async () => {
@@ -306,7 +305,7 @@ describe('run', () => {
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
     getTemplateRequiredServiceNames.mockReturnValueOnce([])
 
-    expect.assertions(8)
+    expect.assertions(7)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toBeCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toBeCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
@@ -318,7 +317,6 @@ describe('run', () => {
         templateName
       ]
     })
-    expect(stdout.output).not.toMatch('Please check the following template dependencies, that should be met by Adobe Console project workspaces:')
   })
 
   test('install from package name - already installed', async () => {

--- a/test/lib/template-helper.test.js
+++ b/test/lib/template-helper.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-const { getTemplateRequiredServices } = require('../../src/lib/template-helper')
+const { getTemplateRequiredServices, getTemplateRequiredServiceNames } = require('../../src/lib/template-helper')
 const templateHandler = require('@adobe/aio-lib-console-project-installation')
 const path = require('path')
 
@@ -24,5 +24,19 @@ describe('Getting services required by a template', () => {
     templateHandler.getTemplateRequiredServices.mockReturnValueOnce(templateRequiredServices)
     expect(getTemplateRequiredServices(npmPackageName)).toEqual(templateRequiredServices)
     expect(templateHandler.getTemplateRequiredServices).toBeCalledWith(templateConfigurationFile)
+  })
+
+  test('Getting a list of service names required by a template', () => {
+    const npmPackageName = '@adobe/template'
+    const templateRequiredServices = { runtime: true, apis: [{ code: 'GraphQLServiceSDK' }, { code: 'AssetComputeSDK' }] }
+    templateHandler.getTemplateRequiredServices.mockReturnValueOnce(templateRequiredServices)
+    expect(getTemplateRequiredServiceNames(npmPackageName)).toEqual(['runtime', 'GraphQLServiceSDK', 'AssetComputeSDK'])
+  })
+
+  test('Getting a list of service names required by a template with no services specified', () => {
+    const npmPackageName = '@adobe/template'
+    const templateRequiredServices = { runtime: false, apis: [] }
+    templateHandler.getTemplateRequiredServices.mockReturnValueOnce(templateRequiredServices)
+    expect(getTemplateRequiredServiceNames(npmPackageName)).toEqual([])
   })
 })

--- a/test/lib/template-helper.test.js
+++ b/test/lib/template-helper.test.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Adobe Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const { getTemplateRequiredServices } = require('../../src/lib/template-helper')
+const templateHandler = require('@adobe/aio-lib-console-project-installation')
+const path = require('path')
+
+jest.mock('@adobe/aio-lib-console-project-installation')
+
+describe('Getting services required by a template', () => {
+  test('Getting services required by a template', () => {
+    const npmPackageName = '@adobe/template'
+    const templateConfigurationFile = path.join(process.cwd(), 'node_modules', npmPackageName, 'install.yml')
+    const templateRequiredServices = { runtime: true, apis: [{ code: 'GraphQLServiceSDK' }, { code: 'AssetComputeSDK' }] }
+    templateHandler.getTemplateRequiredServices.mockReturnValueOnce(templateRequiredServices)
+    expect(getTemplateRequiredServices(npmPackageName)).toEqual(templateRequiredServices)
+    expect(templateHandler.getTemplateRequiredServices).toBeCalledWith(templateConfigurationFile)
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1) Add the `--required-services` flag to the `aio templates info` command to output services required by installed templates.
For example:
```
$ aio templates info --required-services
@adobe/generator-app-api-mesh@^0.1.0 (0.1.0) Required services: runtime, GraphQLServiceSDK
@adobe/generator-app-asset-compute@^0.2.3 (0.2.3) Required services: runtime, AssetComputeSDK
```
2) Output a list of services required by a template after a template installation if the `--no-process-install-config` flag was set, that is the case for `aio app init --no-login`
For example:
```
$ aio templates install --no-process-install-config @adobe/generator-app-asset-compute
...
✔ Finished running template @adobe/generator-app-asset-compute

! Please check the following template dependencies, that should be met by Adobe Console project workspaces: runtime, AssetComputeSDK
```

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-app-templates/issues/11

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- npm test
- manually executing `aio templates install`, `aio templates info --required-services` and checking output

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
