### PR TITLE
Remove ts-node

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -14,13 +14,8 @@ governing permissions and limitations under the License.
 
 const oclif = require('@oclif/core')
 
-const path = require('path')
-const project = path.join(__dirname, '..', 'tsconfig.json')
-
-// In dev mode -> use ts-node and dev plugins
+// In dev mode -> use dev plugins
 process.env.NODE_ENV = 'development'
-
-require('ts-node').register({ project })
 
 // In dev mode, always show stack traces
 oclif.settings.debug = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `ts-node` from `bin/dev` as the `ts-node` dependency was removed in https://github.com/adobe/aio-cli-plugin-app-templates/pull/40/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49

<!--- Describe your changes in detail -->

## Related Issue

- ACNA-1782
- https://github.com/adobe/aio-cli-plugin-app-templates/pull/37

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- Running `bin/dev` locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
