### PR TITLE
feat: npm v8 install support

### DIFF
--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -38,9 +38,9 @@ class InstallCommand extends BaseCommand {
     aioLogger.debug(`read package.json: ${JSON.stringify(packageJson, null, 2)}`)
 
     const packageSpec = processNpmPackageSpec(args.path)
-    if (packageSpec.url) {
+    if (packageSpec.urlSpec || packageSpec.githubSpec) {
       // if it's a url, we don't know the package name, so we have to do a reverse lookup
-      [templateName] = await getNpmDependency({ urlSpec: packageSpec.url })
+      [templateName] = await getNpmDependency({ urlSpec: packageSpec.urlSpec, githubSpec: packageSpec.githubSpec })
     } else {
       templateName = packageSpec.name
     }

--- a/src/lib/npm-helper.js
+++ b/src/lib/npm-helper.js
@@ -58,7 +58,7 @@ function processNpmPackageSpec (npmPackageSpec, dir = process.cwd()) {
 
   if (spec.includes('://github.com/')) {
     githubSpec = `github:${spec.split('://github.com/')[1]}`
-    if (githubSpec.includes('.git')) {
+    if (githubSpec.endsWith('.git')) {
       githubSpec = githubSpec.replace('.git', '')
     }
   }

--- a/src/lib/npm-helper.js
+++ b/src/lib/npm-helper.js
@@ -58,6 +58,9 @@ function processNpmPackageSpec (npmPackageSpec, dir = process.cwd()) {
 
   if (spec.includes('://github.com/')) {
     githubSpec = `github:${spec.split('://github.com/')[1]}`
+    if (githubSpec.includes('.git')) {
+      githubSpec = githubSpec.replace('.git', '')
+    }
   }
 
   if (

--- a/src/lib/npm-helper.js
+++ b/src/lib/npm-helper.js
@@ -136,11 +136,12 @@ async function getNpmDependency ({ packageName, urlSpec, githubSpec }, dir = pro
         aioLogger.debug(`k,v: ${key}, ${value}`)
         return key === packageName
       })
-  } else if (urlSpec) {
+  } else if (urlSpec || githubSpec) {
     return Object.entries(packageJson.dependencies || {})
       .find(([key, value]) => {
         aioLogger.debug(`k,v: ${key}, ${value}`)
-        aioLogger.debug(urlSpec)
+        aioLogger.debug(`urlSpec: ${urlSpec}`)
+        aioLogger.debug(`githubSpec: ${githubSpec}`)
         return value === urlSpec || value === githubSpec
       })
   }

--- a/src/lib/npm-helper.js
+++ b/src/lib/npm-helper.js
@@ -53,22 +53,26 @@ async function npmTextSearch (text) {
  * @returns {object} returns an object with properties url, name, tagOrVersion (if applicable)
  */
 function processNpmPackageSpec (npmPackageSpec, dir = process.cwd()) {
-  let url, name, tagOrVersion
+  let urlSpec, githubSpec, name, tagOrVersion
   const spec = npmPackageSpec.trim()
+
+  if (spec.includes('://github.com/')) {
+    githubSpec = `github:${spec.split('://github.com/')[1]}`
+  }
 
   if (
     spec.startsWith('https://') ||
     spec.startsWith('http://') ||
     spec.startsWith('ssh://')) {
-    url = `git+${spec}`
-    if (!url.endsWith('.git')) {
-      url = `${url}.git`
+    urlSpec = `git+${spec}`
+    if (!urlSpec.endsWith('.git')) {
+      urlSpec = `${urlSpec}.git`
     }
   } else if (
     spec.startsWith('git+https://') ||
     spec.startsWith('git+http://') ||
     spec.startsWith('git+ssh://')) {
-    url = spec
+    urlSpec = spec
   } else if (spec.includes('@')) {
     // separate tag/version, if any. also, it could be a scope
     if (spec.startsWith('@')) {
@@ -90,13 +94,13 @@ function processNpmPackageSpec (npmPackageSpec, dir = process.cwd()) {
       filePath = path.relative(dir, filePath)
     }
 
-    url = `file:${filePath}`
+    urlSpec = `file:${filePath}`
   } else { // it's a plain package name
     name = spec
     tagOrVersion = 'latest'
   }
 
-  return { url, name, tagOrVersion }
+  return { urlSpec, githubSpec, name, tagOrVersion }
 }
 
 /** @private */
@@ -118,7 +122,7 @@ async function writeObjectToPackageJson (obj, dir = process.cwd()) {
 }
 
 /** @private */
-async function getNpmDependency ({ packageName, urlSpec }, dir = process.cwd()) {
+async function getNpmDependency ({ packageName, urlSpec, githubSpec }, dir = process.cwd()) {
   // go through package.json and find the key for the urlSpec
   const packageJson = await readPackageJson(dir)
   aioLogger.debug(`getNpmPackageName package.json: ${JSON.stringify(packageJson, null, 2)}`)
@@ -133,7 +137,8 @@ async function getNpmDependency ({ packageName, urlSpec }, dir = process.cwd()) 
     return Object.entries(packageJson.dependencies || {})
       .find(([key, value]) => {
         aioLogger.debug(`k,v: ${key}, ${value}`)
-        return value === urlSpec
+        aioLogger.debug(urlSpec)
+        return value === urlSpec || value === githubSpec
       })
   }
 

--- a/test/lib/npm-helper.test.js
+++ b/test/lib/npm-helper.test.js
@@ -50,16 +50,16 @@ describe('processNpmPackageSpec', () => {
     const domainAndPath = 'my-server.com/repo'
 
     result = processNpmPackageSpec(`http://${domainAndPath}.git`, cwd) // url ends with .git
-    expect(result).toEqual({ url: `git+http://${domainAndPath}.git` })
+    expect(result).toEqual({ urlSpec: `git+http://${domainAndPath}.git` })
 
     result = processNpmPackageSpec(`http://${domainAndPath}`, cwd)
-    expect(result).toEqual({ url: `git+http://${domainAndPath}.git` })
+    expect(result).toEqual({ urlSpec: `git+http://${domainAndPath}.git` })
 
     result = processNpmPackageSpec(`https://${domainAndPath}`, cwd)
-    expect(result).toEqual({ url: `git+https://${domainAndPath}.git` })
+    expect(result).toEqual({ urlSpec: `git+https://${domainAndPath}.git` })
 
     result = processNpmPackageSpec(`ssh://${domainAndPath}`, cwd)
-    expect(result).toEqual({ url: `git+ssh://${domainAndPath}.git` })
+    expect(result).toEqual({ urlSpec: `git+ssh://${domainAndPath}.git` })
   })
 
   test('git+http, git+https, ssh, git+ssh urls', async () => {
@@ -67,13 +67,13 @@ describe('processNpmPackageSpec', () => {
     const domainAndPath = 'my-server.com/repo'
 
     result = processNpmPackageSpec(`git+http://${domainAndPath}.git`, cwd)
-    expect(result).toEqual({ url: `git+http://${domainAndPath}.git` })
+    expect(result).toEqual({ urlSpec: `git+http://${domainAndPath}.git` })
 
     result = processNpmPackageSpec(`git+https://${domainAndPath}.git`, cwd)
-    expect(result).toEqual({ url: `git+https://${domainAndPath}.git` })
+    expect(result).toEqual({ urlSpec: `git+https://${domainAndPath}.git` })
 
     result = processNpmPackageSpec(`git+ssh://${domainAndPath}.git`, cwd)
-    expect(result).toEqual({ url: `git+ssh://${domainAndPath}.git` })
+    expect(result).toEqual({ urlSpec: `git+ssh://${domainAndPath}.git` })
   })
 
   test('file: urls (with absolute, relative paths)', async () => {
@@ -82,10 +82,10 @@ describe('processNpmPackageSpec', () => {
     const relFolderPath = path.join('a', 'd')
 
     result = processNpmPackageSpec(`file:${absFolderPath}`, cwd)
-    expect(result).toEqual({ url: `file:${relFolderPath}` })
+    expect(result).toEqual({ urlSpec: `file:${relFolderPath}` })
 
     result = processNpmPackageSpec(`file:${relFolderPath}`, cwd)
-    expect(result).toEqual({ url: `file:${relFolderPath}` })
+    expect(result).toEqual({ urlSpec: `file:${relFolderPath}` })
   })
 
   test('file paths (absolute, relative)', async () => {
@@ -94,10 +94,10 @@ describe('processNpmPackageSpec', () => {
     const relFolderPath = path.join('a', 'd')
 
     result = processNpmPackageSpec(absFolderPath, cwd)
-    expect(result).toEqual({ url: `file:${relFolderPath}` })
+    expect(result).toEqual({ urlSpec: `file:${relFolderPath}` })
 
     result = processNpmPackageSpec(relFolderPath, cwd)
-    expect(result).toEqual({ url: `file:${relFolderPath}` })
+    expect(result).toEqual({ urlSpec: `file:${relFolderPath}` })
   })
 
   test('file paths (absolute, relative) - use process.cwd()', async () => {
@@ -106,10 +106,10 @@ describe('processNpmPackageSpec', () => {
     const relFolderPath = path.relative(processCwd, absFolderPath)
 
     result = processNpmPackageSpec(absFolderPath)
-    expect(result).toEqual({ url: `file:${relFolderPath}` })
+    expect(result).toEqual({ urlSpec: `file:${relFolderPath}` })
 
     result = processNpmPackageSpec(relFolderPath)
-    expect(result).toEqual({ url: `file:${relFolderPath}` })
+    expect(result).toEqual({ urlSpec: `file:${relFolderPath}` })
   })
 
   test('npm package name (no scope, no tag/version)', async () => {

--- a/test/lib/npm-helper.test.js
+++ b/test/lib/npm-helper.test.js
@@ -62,6 +62,24 @@ describe('processNpmPackageSpec', () => {
     expect(result).toEqual({ urlSpec: `git+ssh://${domainAndPath}.git` })
   })
 
+  test('github', async () => {
+    let result
+    const orgAndRepo = 'org/repo'
+    const domainAndPath = `github.com/${orgAndRepo}`
+
+    result = processNpmPackageSpec(`http://${domainAndPath}.git`, cwd) // url ends with .git
+    expect(result).toEqual(expect.objectContaining({ githubSpec: `github:${orgAndRepo}` }))
+
+    result = processNpmPackageSpec(`http://${domainAndPath}`, cwd)
+    expect(result).toEqual(expect.objectContaining({ githubSpec: `github:${orgAndRepo}` }))
+
+    result = processNpmPackageSpec(`https://${domainAndPath}`, cwd)
+    expect(result).toEqual(expect.objectContaining({ githubSpec: `github:${orgAndRepo}` }))
+
+    result = processNpmPackageSpec(`ssh://${domainAndPath}`, cwd)
+    expect(result).toEqual(expect.objectContaining({ githubSpec: `github:${orgAndRepo}` }))
+  })
+
   test('git+http, git+https, ssh, git+ssh urls', async () => {
     let result
     const domainAndPath = 'my-server.com/repo'


### PR DESCRIPTION
## Description

Add support for installing templates with npm v8+, which seems to use a different schema for package dependency values when installing packages directly from github. 

Before v8 (https): `git+https://github.com/adobe/generator-app-asset-compute.git`
v8+: `github:org/repo`

## Related Issue

Closes https://github.com/adobe/aio-cli-plugin-app-templates/issues/47

## How Has This Been Tested?

Locally linked template plugin & `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
