### PR TITLE
fix: usage of load function from @adobe/aio-cli-lib-app-config was not async

### DIFF
--- a/src/commands/templates/discover.js
+++ b/src/commands/templates/discover.js
@@ -34,7 +34,7 @@ class DiscoverCommand extends BaseCommand {
     const apiKey = env.getCliEnv() === 'prod' ? 'aio-cli-console-auth' : 'aio-cli-console-auth-stage'
     const consoleCLI = await LibConsoleCLI.init({ accessToken: this.accessToken, env: env.getCliEnv(), apiKey })
 
-    const appConfig = loadConfig({})
+    const appConfig = await loadConfig({})
     let orgId = appConfig?.aio?.project?.org?.id
     if (!orgId) {
       const organizations = await consoleCLI.getOrganizations()

--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -111,7 +111,7 @@ class InstallCommand extends BaseCommand {
     const templateManager = await templateHandler.init(this.accessToken, installConfigFile)
 
     // 3. Install the template
-    const appConfig = loadConfig({})
+    const appConfig = await loadConfig({})
     const orgId = appConfig?.aio?.project?.org?.id
     const projectId = appConfig?.aio?.project?.id
     if (orgId && projectId) {

--- a/test/commands/templates/discover.test.js
+++ b/test/commands/templates/discover.test.js
@@ -206,7 +206,7 @@ describe('interactive install', () => {
   test('normal choices', async () => {
     getTemplates.mockReturnValue(templates)
     libEnv.getCliEnv.mockReturnValue('prod')
-    loadConfig.mockImplementation(() => mockAIOConfigJSON)
+    loadConfig.mockResolvedValue(mockAIOConfigJSON)
     mockConsoleCLIInstance.getEnabledServicesForOrg.mockResolvedValue(fakeSupportedOrgServices)
     // default values for Order By
     const orderByCriteria = {
@@ -234,7 +234,7 @@ describe('interactive install', () => {
   test('org does not support all services', async () => {
     getTemplates.mockReturnValue(templates)
     libEnv.getCliEnv.mockReturnValue('prod')
-    loadConfig.mockImplementation(() => {})
+    loadConfig.mockResolvedValue(undefined)
     const supportedOrgServices = [{ code: 'ViewSDK', properties: {} }, { code: 'UserMgmtSDK', properties: {} }, { code: 'McPlacesSDK', properties: {} }]
     const fakeOrg = { id: 'fakeorgid', name: 'bestorg' }
     mockConsoleCLIInstance.promptForSelectOrganization.mockResolvedValue(fakeOrg)
@@ -266,7 +266,7 @@ describe('interactive install', () => {
   test('all templates are already installed', async () => {
     getTemplates.mockReturnValue(templates)
     libEnv.getCliEnv.mockReturnValue('prod')
-    loadConfig.mockImplementation(() => mockAIOConfigJSON)
+    loadConfig.mockResolvedValue(mockAIOConfigJSON)
     mockConsoleCLIInstance.getEnabledServicesForOrg.mockResolvedValue(fakeSupportedOrgServices)
     // default values for Order By
     const orderByCriteria = {
@@ -293,7 +293,7 @@ describe('interactive install', () => {
   test('no choices', async () => {
     getTemplates.mockReturnValue([])
     libEnv.getCliEnv.mockReturnValue('stage')
-    loadConfig.mockImplementation(() => mockAIOConfigJSON)
+    loadConfig.mockResolvedValue(mockAIOConfigJSON)
     mockConsoleCLIInstance.getEnabledServicesForOrg.mockResolvedValue(fakeSupportedOrgServices)
     // default values for Order By
     const orderByCriteria = {

--- a/test/commands/templates/install.test.js
+++ b/test/commands/templates/install.test.js
@@ -27,7 +27,7 @@ TemplateHandler.init.mockResolvedValue(mockTemplateHandlerInstance)
 jest.mock('@adobe/aio-cli-lib-app-config')
 const { load: loadConfig } = require('@adobe/aio-cli-lib-app-config')
 const mockAIOConfigJSON = JSON.parse('{"aio": {"project": {"id": "project-id","org": {"id": "org-id"}}}}')
-loadConfig.mockImplementation(() => mockAIOConfigJSON)
+loadConfig.mockResolvedValue(mockAIOConfigJSON)
 
 // mock ims calls
 jest.mock('@adobe/aio-lib-ims', () => ({


### PR DESCRIPTION
## Description

The require/import was changed to properly use the new major version of `@adobe/aio-cli-lib-app-config`, but the code calling the function did not `await` the call.

The unit tests were not updated to mock the resolved value via mockResolvedValue (it used mockImplementation, which was correct for the previous library version), so this failure was not detected in the previous change.

## How Has This Been Tested?

- `npm test`
- `aio plugins link` this plugin and testing it with `aio app init` and choosing the `@adobe/generator-app-excshell` template
 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
