### PR TITLE
fix: destructure property error

### DIFF
--- a/src/commands/templates/install.js
+++ b/src/commands/templates/install.js
@@ -63,7 +63,7 @@ class InstallCommand extends BaseCommand {
     aioLogger.debug(`flags['template-options']: ${JSON.stringify(templateOptions)}`)
 
     const templatePath = require.resolve(templateName, { paths: [process.cwd()] })
-    const gen = env.instantiate(require(templatePath), {
+    const gen = await env.instantiate(require(templatePath), {
       options: { ...defaultOptions, ...templateOptions }
     })
     await env.runGenerator(gen)

--- a/test/commands/templates/install.test.js
+++ b/test/commands/templates/install.test.js
@@ -41,12 +41,13 @@ Ims.context.setCli.mockReset()
 Ims.getToken.mockReset()
 Ims.getToken.mockResolvedValue('bowling')
 
-const yeomanEnvInstantiate = jest.fn()
+const yeomanEnvInstantiate = jest.fn(async () => ({}))
+const yeomanEnvRunGenerator = jest.fn()
 const yeomanEnvOptionsGet = jest.fn()
 const yeomanEnvOptionsSet = jest.fn()
 const createEnvReturnValue = {
   instantiate: yeomanEnvInstantiate,
-  runGenerator: jest.fn()
+  runGenerator: yeomanEnvRunGenerator
 }
 Object.defineProperty(createEnvReturnValue, 'options', {
   get: yeomanEnvOptionsGet,
@@ -146,11 +147,12 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', argPath])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).toHaveBeenCalledWith('org-id', 'project-id')
     expect(getTemplateRequiredServiceNames).not.toHaveBeenCalled()
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({
@@ -172,11 +174,12 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).toHaveBeenCalledWith('org-id', 'project-id')
     expect(getTemplateRequiredServiceNames).not.toHaveBeenCalled()
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({
@@ -198,11 +201,12 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': true, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).toHaveBeenCalledWith('org-id', 'project-id')
     expect(getTemplateRequiredServiceNames).not.toHaveBeenCalled()
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({
@@ -224,11 +228,12 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: true })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).toHaveBeenCalledWith('org-id', 'project-id')
     expect(getTemplateRequiredServiceNames).not.toHaveBeenCalled()
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({
@@ -250,11 +255,12 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).toHaveBeenCalledWith('org-id', 'project-id')
     expect(getTemplateRequiredServiceNames).not.toHaveBeenCalled()
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({
@@ -277,11 +283,12 @@ describe('run', () => {
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
     getTemplateRequiredServiceNames.mockReturnValueOnce(['runtime', 'GraphQLServiceSDK', 'AssetComputeSDK'])
 
-    expect.assertions(8)
+    expect.assertions(9)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).not.toHaveBeenCalled()
     expect(getTemplateRequiredServiceNames).toHaveBeenCalledWith(templateName)
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({
@@ -305,11 +312,12 @@ describe('run', () => {
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
     getTemplateRequiredServiceNames.mockReturnValueOnce([])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).not.toHaveBeenCalled()
     expect(getTemplateRequiredServiceNames).toHaveBeenCalledWith(templateName)
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({
@@ -334,11 +342,12 @@ describe('run', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', templateName])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).toHaveBeenCalledWith('org-id', 'project-id')
     expect(getTemplateRequiredServiceNames).not.toHaveBeenCalled()
     expect(writeObjectToPackageJson).not.toHaveBeenCalled()
@@ -377,11 +386,12 @@ describe('template-options', () => {
 
     getNpmDependency.mockResolvedValueOnce([templateName, '1.0.0'])
 
-    expect.assertions(7)
+    expect.assertions(8)
     await expect(command.run()).resolves.toBeUndefined()
     expect(runScript).toHaveBeenCalledWith('npm', process.cwd(), ['install', argPath])
     expect(yeomanEnvInstantiate).toHaveBeenCalledWith(expect.any(Object), { options: { 'skip-prompt': false, force: true } })
     expect(yeomanEnvOptionsSet).toHaveBeenCalledWith({ skipInstall: false })
+    expect(yeomanEnvRunGenerator).toHaveBeenCalledWith(expect.any(Object))
     expect(mockTemplateHandlerInstance.installTemplate).toHaveBeenCalledWith('org-id', 'project-id')
     expect(getTemplateRequiredServiceNames).not.toHaveBeenCalled()
     expect(writeObjectToPackageJson).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description

Installing templates with latest cli produces the following: 
```
Running template @adobe/generator-app-excshell
 ›   Error: Cannot destructure property 'namespace' of 'generator.options' as it is undefined.
```

Looks like this is because `env.instantiate()` changed to be an async function with yeoman-environment v4, so after the upgrade with 2.0.2, the plugin started passing a promise to `env.runGenerator()` instead of a yeoman generator. This PR adds an await when instantiating so we pass the generator

## Related Issue

## Motivation and Context

## How Has This Been Tested?

Locally linked plugin, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
