### PR TITLE
fix: code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,12 @@ aio aio-cli-plugin-app-templates --help
 # Commands
 <!-- commands -->
 * [`aio templates`](#aio-templates)
-* [`aio templates disco`](#aio-templates-disco)
 * [`aio templates discover`](#aio-templates-discover)
-* [`aio templates i PATH`](#aio-templates-i-path)
 * [`aio templates info`](#aio-templates-info)
 * [`aio templates install PATH`](#aio-templates-install-path)
 * [`aio templates remove NAME`](#aio-templates-remove-name)
-* [`aio templates rm NAME`](#aio-templates-rm-name)
 * [`aio templates rollback`](#aio-templates-rollback)
-* [`aio templates sub NAME GITHUBREPOURL`](#aio-templates-sub-name-githubrepourl)
 * [`aio templates submit NAME GITHUBREPOURL`](#aio-templates-submit-name-githubrepourl)
-* [`aio templates un PACKAGE-NAME`](#aio-templates-un-package-name)
 * [`aio templates uninstall PACKAGE-NAME`](#aio-templates-uninstall-package-name)
 
 ## `aio templates`
@@ -74,32 +69,7 @@ DESCRIPTION
   Discover, install, or uninstall a new template into an existing Adobe Developer App Builder App
 ```
 
-_See code: [src/commands/templates/index.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/index.ts)_
-
-## `aio templates disco`
-
-Discover App Builder templates to install
-
-```
-USAGE
-  $ aio templates disco [-v] [-i] [-f publishDate|names|adobeRecommended] [-o asc|desc]
-
-FLAGS
-  -f, --sort-field=<option>  [default: adobeRecommended] which column to sort, use the sort-order flag to specify sort
-                             direction
-                             <options: publishDate|names|adobeRecommended>
-  -i, --interactive          interactive install mode
-  -o, --sort-order=<option>  [default: desc] sort order for a column, use the sort-field flag to specify which column to
-                             sort
-                             <options: asc|desc>
-  -v, --verbose              Verbose output
-
-DESCRIPTION
-  Discover App Builder templates to install
-
-ALIASES
-  $ aio templates disco
-```
+_See code: [src/commands/templates/index.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/index.js)_
 
 ## `aio templates discover`
 
@@ -126,58 +96,7 @@ ALIASES
   $ aio templates disco
 ```
 
-_See code: [src/commands/templates/discover.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/discover.ts)_
-
-## `aio templates i PATH`
-
-Install an Adobe Developer App Builder template
-
-```
-USAGE
-  $ aio templates i PATH [-v] [-y] [--install] [--process-install-config] [--template-options <value>]
-
-ARGUMENTS
-  PATH  path to the template (npm package name, file path, url). See examples
-
-FLAGS
-  -v, --verbose                      Verbose output
-  -y, --yes                          Skip questions, and use all default values
-      --[no-]install                 [default: true] Run npm installation after files are created
-      --[no-]process-install-config  [default: true] Process the template install.yml configuration file, defaults to
-                                     true, to skip processing install.yml use --no-process-install-config
-      --template-options=<value>     Additional template options, as a base64-encoded json string
-
-DESCRIPTION
-  Install an Adobe Developer App Builder template
-
-ALIASES
-  $ aio templates i
-
-EXAMPLES
-  $ aio templates install https://github.com/org/repo
-
-  $ aio templates install git+https://github.com/org/repo
-
-  $ aio templates install ssh://github.com/org/repo
-
-  $ aio templates install git+ssh://github.com/org/repo
-
-  $ aio templates install file:../relative/path/to/template/folder
-
-  $ aio templates install file:/absolute/path/to/template/folder
-
-  $ aio templates install ../relative/path/to/template/folder
-
-  $ aio templates install /absolute/path/to/template/folder
-
-  $ aio templates install npm-package-name
-
-  $ aio templates install npm-package-name@tagOrVersion
-
-  $ aio templates install @scope/npm-package-name
-
-  $ aio templates install @scope/npm-package-name@tagOrVersion
-```
+_See code: [src/commands/templates/discover.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/discover.js)_
 
 ## `aio templates info`
 
@@ -197,7 +116,7 @@ DESCRIPTION
   List all App Builder templates that are installed
 ```
 
-_See code: [src/commands/templates/info.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/info.ts)_
+_See code: [src/commands/templates/info.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/info.js)_
 
 ## `aio templates install PATH`
 
@@ -250,7 +169,7 @@ EXAMPLES
   $ aio templates install @scope/npm-package-name@tagOrVersion
 ```
 
-_See code: [src/commands/templates/install.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/install.ts)_
+_See code: [src/commands/templates/install.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/install.js)_
 
 ## `aio templates remove NAME`
 
@@ -276,31 +195,7 @@ EXAMPLES
   $ aio templates remove @adobe/app-builder-template
 ```
 
-_See code: [src/commands/templates/remove.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/remove.ts)_
-
-## `aio templates rm NAME`
-
-Remove an Adobe Developer App Builder template from the Template Registry
-
-```
-USAGE
-  $ aio templates rm NAME [-v]
-
-ARGUMENTS
-  NAME  The name of the package implementing the template on npmjs.com
-
-FLAGS
-  -v, --verbose  Verbose output
-
-DESCRIPTION
-  Remove an Adobe Developer App Builder template from the Template Registry
-
-ALIASES
-  $ aio templates rm
-
-EXAMPLES
-  $ aio templates remove @adobe/app-builder-template
-```
+_See code: [src/commands/templates/remove.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/remove.js)_
 
 ## `aio templates rollback`
 
@@ -320,32 +215,7 @@ DESCRIPTION
   Clears all installed templates
 ```
 
-_See code: [src/commands/templates/rollback.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/rollback.ts)_
-
-## `aio templates sub NAME GITHUBREPOURL`
-
-Submit an Adobe Developer App Builder template
-
-```
-USAGE
-  $ aio templates sub NAME GITHUBREPOURL [-v]
-
-ARGUMENTS
-  NAME           The name of the package implementing the template on npmjs.com
-  GITHUBREPOURL  A link to the Github repository containing the package's source code
-
-FLAGS
-  -v, --verbose  Verbose output
-
-DESCRIPTION
-  Submit an Adobe Developer App Builder template
-
-ALIASES
-  $ aio templates sub
-
-EXAMPLES
-  $ aio templates submit @adobe/app-builder-template https://github.com/adobe/app-builder-template
-```
+_See code: [src/commands/templates/rollback.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/rollback.js)_
 
 ## `aio templates submit NAME GITHUBREPOURL`
 
@@ -372,28 +242,7 @@ EXAMPLES
   $ aio templates submit @adobe/app-builder-template https://github.com/adobe/app-builder-template
 ```
 
-_See code: [src/commands/templates/submit.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/submit.ts)_
-
-## `aio templates un PACKAGE-NAME`
-
-Uninstall an Adobe Developer App Builder template
-
-```
-USAGE
-  $ aio templates un PACKAGE-NAME [-v]
-
-ARGUMENTS
-  PACKAGE-NAME  package name of the template
-
-FLAGS
-  -v, --verbose  Verbose output
-
-DESCRIPTION
-  Uninstall an Adobe Developer App Builder template
-
-ALIASES
-  $ aio templates un
-```
+_See code: [src/commands/templates/submit.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/submit.js)_
 
 ## `aio templates uninstall PACKAGE-NAME`
 
@@ -416,7 +265,7 @@ ALIASES
   $ aio templates un
 ```
 
-_See code: [src/commands/templates/uninstall.ts](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/uninstall.ts)_
+_See code: [src/commands/templates/uninstall.js](https://github.com/adobe/aio-cli-plugin-app-templates/blob/2.0.2/src/commands/templates/uninstall.js)_
 <!-- commandsstop -->
 
 # Contributing

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "yeoman-environment": "^4.2.1"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.2",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "@types/jest": "^28.1.5",
     "acorn": "^7",
     "cross-env": "^7.0.3",
@@ -45,8 +45,7 @@
     "jest-junit": "^6.0.0",
     "jest-resolve": "^24.5.0",
     "oclif": "^4.3.6",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^5.3.3"
+    "stdout-stderr": "^0.1.9"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #65 

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.