### PR TITLE
fix: upgrade yeoman-environment to v6 to resolve 6 high-severity tar CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "inquirer": "^8.2.4",
     "js-yaml": "^3.14.1",
     "ora": "^4.1.1",
-    "yeoman-environment": "^4.2.1"
+    "yeoman-environment": "^6.1.0"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "5.0.0",


### PR DESCRIPTION
## Summary

Upgrades `yeoman-environment` from `^4.2.1` to `^6.1.0` in `package.json`. This is a one-line dependency change that eliminates all 7 open vulnerability findings (6 high, 1 low) reported by `npm audit`.

## Root cause

The v4 dependency chain pulled in `tar <=7.5.10` through:

```
yeoman-environment@4.x → fly-import@0.4.1 → @npmcli/arborist@7.x → cacache@18.x → tar@6.2.1
```

`tar@6.2.1` carries 6 high-severity path traversal/symlink CVEs. The v6 chain resolves cleanly:

```
yeoman-environment@6.x → fly-import@1.0.0 → @npmcli/arborist@9.x → cacache@20.x → tar@7.5.15 ✓
```

## CVEs resolved

| CVE | CVSS | Description |
|---|---|---|
| CVE-2026-23950 | 8.8 High | Race condition via Unicode ligature (ß/ss) collisions on macOS APFS — symlink poisoning |
| CVE-2026-23745 | 8.2 High | Arbitrary file overwrite and symlink poisoning via insufficient path sanitization |
| CVE-2026-24842 | 8.2 High | Arbitrary file creation/overwrite via hardlink path traversal |
| CVE-2026-29786 | 8.2 High | Hardlink path traversal via drive-relative linkpath (e.g. `C:../target.txt`) |
| CVE-2026-31802 | 8.2 High | Symlink path traversal via drive-relative linkpath |
| CVE-2026-26960 | 7.1 High | Arbitrary file read/write via hardlink target escape through symlink chain |
| CVE-2026-24001 | 2.7 Low | DoS / infinite loop in `diff` `parsePatch`/`applyPatch` via line break chars in filenames |

## API compatibility analysis

The three yeoman-environment methods used in `src/commands/templates/install.js` were verified by direct source inspection of both v4.4.3 and v6.1.0:

- **`createEnv()`** — identical export signature in both versions
- **`env.instantiate(constructor, { options: {...} })`** — present in both; the `{ options: {...} }` call form is handled by an explicit backward-compatibility branch in v6's `getInstantiateOptions`, identical logic to v4
- **`env.runGenerator(gen)`** — body is character-for-character identical in both versions
- **`env.options` property assignment** — plain writable property in both versions

Old-style generators (without `queueTasks()`) run via the `compatibilityMode = 'v4'` path in both versions, which is identical.

## Validation

- `npm audit` after upgrade: **0 vulnerabilities** (was 17: 2 low, 15 high)
- Full test suite on Node 24 with `NODE_OPTIONS=--experimental-vm-modules`: **151/151 tests passing, 100% coverage across all files**
- `npm install` result: 46 packages added, 110 removed, 110 changed — consistent with the dependency chain swap